### PR TITLE
Practical improvement for IS_RSA_SEMIPRIME

### DIFF
--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -258,11 +258,10 @@ int main()
 
     const bitLenInt primeBits = (qubitCount + 1U) >> 1U;
     const bitCapInt fullMinR = primeDict[primeBits] ? primeDict[primeBits] : ((ONE_BCI << (primeBits - 1U)) + 1);
-    const bitCapInt fullMaxR = toFactor / fullMinR;
 #else
     const bitCapInt fullMinR = 2U;
-    const bitCapInt fullMaxR = toFactor / 2;
 #endif
+    const bitCapInt fullMaxR = toFactor / 2;
     const bitCapInt nodeRange = (fullMaxR + 1U - fullMinR) / nodeCount;
     const bitCapInt nodeMin = fullMinR + nodeRange * nodeId;
     const bitCapInt nodeMax = ((nodeId + 1U) == nodeCount) ? fullMaxR : (fullMinR + nodeRange * (nodeId + 1U) - 1U);

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -312,8 +312,8 @@ int main()
                 do {
                     phi >>= 1U;
                     apowrhalf = uipow(base, phi) % toFactor;
-                } while ((apowrhalf == 1) && (phi > 2U));
-                if (phi < 2U) {
+                } while ((apowrhalf == 1) && ((phi & 1U) == 0));
+                if ((apowrhalf == 1) || (apowrhalf == (toFactor - 1))) {
                     continue;
                 }
 

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -321,13 +321,12 @@ int main()
                 // However, p is "relatively close" to one of our two factors.
 
                 const bitCapInt q = toFactor / p;
-                TEST_DIVIDE(q, toFactor, "Guessed q: Found");
 
                 // At this point, similarly, q is not a factor, and q is probably not prime.
                 // However, q is "relatively close" to one of our two factors.
 
                 // This guess for lambda might be chaotic.
-                const bitCapInt lambda = (p - 1) * (q - 1) / gcd(p - 1, q - 2);
+                const bitCapInt lambda = (p - 1) * (q - 1) / gcd(p - 1, q - 1);
 
                 const bitCapInt apowrhalf = uipow(base, lambda) % toFactor;
                 if ((apowrhalf == 1) || (apowrhalf == (toFactor - 1))) {

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -63,8 +63,13 @@
 #define ONE_BCI 1ULL
 #endif
 
+#if (QBCAPPOW < 6U) || (IS_RSA_SEMIPRIME && (QBCAPPOW < 7U))
+#define WORD uint32_t
+#define WORD_SIZE 32U
+#else
 #define WORD uint64_t
 #define WORD_SIZE 64U
+#endif
 
 namespace Qimcifa {
 

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -31,8 +31,6 @@
 #include <map>
 #include <mutex>
 
-// Turn this off, if you're not factoring a semi-prime number with equal-bit-width factors.
-#define IS_RSA_SEMIPRIME 1
 // Turn this off, if you don't want to coordinate across multiple (quasi-independent) nodes.
 #define IS_DISTRIBUTED 1
 // The maximum number of bits in Boost big integers is 2^QBCAPPOW.
@@ -251,42 +249,13 @@ int main()
     std::atomic<bool> isFinished;
     isFinished = false;
 
-#if IS_RSA_SEMIPRIME
-    std::map<bitLenInt, const std::vector<bitCapInt>> primeDict = { { 16U, { 32771U, 65521U } },
-        { 28U, { 134217757U, 268435399U } }, { 32U, { 2147483659U, 4294967291U } },
-        { 64U, { 9223372036854775837U, 1844674407370955143U } } };
-
-    // If n is semiprime, \phi(n) = (p - 1) * (q - 1), where "p" and "q" are prime.
-    // The minimum value of this formula, for our input, without consideration of actual
-    // primes in the interval, is as follows:
-    // (See https://www.mobilefish.com/services/rsa_key_generation/rsa_key_generation.php)
-    const bitLenInt primeBits = (qubitCount + 1U) >> 1U;
-    const bitCapInt fullMin = (ONE_BCI << (primeBits - 1U)) + 1;
-    const bitCapInt fullMax = (ONE_BCI << primeBits) - 1U;
-    const bitCapInt minPrime = primeDict[primeBits].size() ? primeDict[primeBits][0] : fullMin;
-    const bitCapInt maxPrime = primeDict[primeBits].size() ? primeDict[primeBits][1] : fullMax;
-    const bitCapInt fullMinR = (minPrime - 1U) * (toFactor / minPrime - 1U);
-    const bitCapInt fullMaxR = (maxPrime - 1U) * (toFactor / maxPrime - 1U);
-#else
-    // \phi(n) is Euler's totient for n. A loose lower bound is \phi(n) >= sqrt(n/2).
-    const bitCapInt fullMinR = floorSqrt(toFactor >> 1U);
-    // A better bound is \phi(n) >= pow(n / 2, log(2)/log(3))
-    // const bitCapInt fullMinR = pow(toFactor / 2, PHI_EXPONENT);
-
-    // It can be shown that the period of this modular exponentiation can be no higher than 1
-    // less than the modulus, as in https://www2.math.upenn.edu/~mlazar/math170/notes06-3.pdf.
-    // Further, an upper bound on Euler's totient for composite numbers is n - sqrt(n). (See
-    // https://math.stackexchange.com/questions/896920/upper-bound-for-eulers-totient-function-on-composite-numbers)
-    const bitCapInt fullMaxR = toFactor - floorSqrt(toFactor);
-#endif
+    const bitCapInt fullMinR = 2U;
+    const bitCapInt fullMaxR = toFactor / 2;
     const bitCapInt nodeRange = (fullMaxR + 1U - fullMinR) / nodeCount;
     const bitCapInt nodeMin = fullMinR + nodeRange * nodeId;
     const bitCapInt nodeMax = ((nodeId + 1U) == nodeCount) ? fullMaxR : (fullMinR + nodeRange * (nodeId + 1U) - 1U);
 
-    std::vector<rand_dist> baseDist = rangeRange(toFactor - 3U);
-
-    auto workerFn = [&nodeId, &nodeCount, &toFactor, &nodeMin, &nodeMax, &baseDist, &iterClock, &rand_gen,
-                        &isFinished](int cpu) {
+    auto workerFn = [&toFactor, &nodeMin, &nodeMax, &iterClock, &rand_gen, &isFinished](int cpu) {
         // These constants are semi-redundant, but they're only defined once per thread,
         // and compilers differ on lambda expression capture of constants.
 
@@ -294,7 +263,7 @@ int main()
         // Batch size is BASE_TRIALS * PERIOD_TRIALS.
 
         // Number of times to reuse a random base:
-        const size_t BASE_TRIALS = 1U << 4U;
+        const size_t BASE_TRIALS = 1U << 6U;
 
         const double clockFactor = 1.0 / 1000.0; // Report in ms
         const unsigned threads = std::thread::hardware_concurrency();
@@ -307,12 +276,12 @@ int main()
         for (;;) {
             for (size_t batchItem = 0U; batchItem < BASE_TRIALS; ++batchItem) {
                 // Choose a base at random, >1 and <toFactor.
-                bitCapInt base = baseDist[0U](rand_gen);
-                for (size_t i = 1U; i < baseDist.size(); ++i) {
+                bitCapInt base = rDist[0U](rand_gen);
+                for (size_t i = 1U; i < rDist.size(); ++i) {
                     base <<= WORD_SIZE;
-                    base |= baseDist[i](rand_gen);
+                    base |= rDist[i](rand_gen);
                 }
-                base += 2U;
+                base += rMin;
 
 #define PRINT_SUCCESS(f1, f2, toFactor, message)                                                                       \
     std::cout << message << (f1) << " * " << (f2) << " = " << (toFactor) << std::endl;                                 \
@@ -330,69 +299,6 @@ int main()
 
                 bitCapInt testFactor = gcd(toFactor, base);
                 TEST_GCD(testFactor, toFactor, "Chose non-relative prime: Found ");
-
-                // This would be where we perform the quantum period finding algorithm.
-                // However, we don't have a quantum computer!
-                // Instead, we "throw dice" for a guess to the output of the quantum subroutine.
-                // This guess will usually be wrong, at least for semi-prime inputs.
-                // If we try many times, though, this can be a practically valuable factoring method.
-
-                // y is meant to be close to some number c * qubitPower / r, where r is the period.
-                // c is a positive integer or 0, and we don't want the 0 case.
-                // y is truncated by the number of qubits in the register, at most.
-                // The maximum value of c before truncation is no higher than r.
-
-                // The period of ((base ^ x) MOD toFactor) can't be smaller than log_base(toFactor).
-                // (Also, toFactor is definitely NOT an exact multiple of base.)
-                // Euler's Theorem tells us, if gcd(a, n) = 1, then a^\phi(n) = 1 MOD n,
-                // where \phi(n) is Euler's totient for n.
-
-                // c is basically a harmonic degeneracy factor, and there might be no value in testing
-                // any case except c = 1, without loss of generality.
-
-                // This sets a nonuniform distribution on our y values to test.
-                // y values are close to qubitPower / rGuess, and we midpoint round.
-
-                // However, results are better with uniformity over r, rather than y.
-
-                // So, we guess r, between fullMinR and fullMaxR.
-                // Since our output is r rather than y, we can skip the continued fractions step.
-                bitCapInt r = rDist[0U](rand_gen);
-                for (size_t i = 1U; i < rDist.size(); ++i) {
-                    r <<= WORD_SIZE;
-                    r |= rDist[i](rand_gen);
-                }
-
-                r += rMin;
-                if (r & 1U) {
-                    r <<= 1U;
-                }
-
-                // As a "classical" optimization, since \phi(toFactor) and factor bounds overlap,
-                // we first check if our guess for r is already a factor.
-                testFactor = gcd(toFactor, r);
-                TEST_GCD(testFactor, toFactor, "Success (on r trial division): Found ");
-
-                const bitCapInt apowrhalf = uipow(base, r) % toFactor;
-                bitCapInt f1 = gcd(apowrhalf + 1U, toFactor);
-                bitCapInt f2 = gcd(apowrhalf - 1U, toFactor);
-                bitCapInt fmul = f1 * f2;
-#if !IS_RSA_SEMIPRIME
-                // There's no chance that (f1 * f2) divides toFactor if f1 > 1 and f2 > 1 unless f1 and f2 are prime.
-                while ((fmul > 1U) && (fmul != toFactor) && ((toFactor % fmul) == 0)) {
-                    fmul = f1;
-                    f1 *= f2;
-                    f2 = toFactor / (fmul * f2);
-                    fmul = f1 * f2;
-                }
-#endif
-                if ((fmul == toFactor) && (f1 > 1U) && (f2 > 1U)) {
-                    // Inform the other threads on this node that we've succeeded and are done:
-                    isFinished = true;
-
-                    PRINT_SUCCESS(f1, f2, toFactor, "Success (on r difference of squares): Found ");
-                    return;
-                }
             }
 
             // Check if finished, between batches.

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -232,11 +232,10 @@ int main()
     const bitCapInt minPrime = primeDict[primeBits].size() ? primeDict[primeBits][0] : ((ONE_BCI << (primeBits - 1U)) + 1U);
     const bitCapInt maxPrime = primeDict[primeBits].size() ? primeDict[primeBits][1] : ((ONE_BCI << primeBits) - 1U);
     const bitCapInt fullMinBase = ((toFactor / maxPrime) < minPrime) ? minPrime : ((toFactor / maxPrime) | 1U);
-    const bitCapInt fullMaxBase = ((toFactor / minPrime) > maxPrime) ? maxPrime : ((toFactor / minPrime) | 1U);
 #else
     const bitCapInt fullMinBase = 2U;
-    const bitCapInt fullMaxBase = toFactor / 2;
 #endif
+    const bitCapInt fullMaxBase = toFactor / 2;
     const bitCapInt nodeRange = (fullMaxBase + 1U - fullMinBase) / nodeCount;
     const bitCapInt nodeMin = fullMinBase + nodeRange * nodeId;
     const bitCapInt nodeMax = ((nodeId + 1U) == nodeCount) ? fullMaxBase : (fullMinBase + nodeRange * (nodeId + 1U) - 1U);
@@ -257,11 +256,7 @@ int main()
         const bitCapInt threadRange = (nodeMax + 1U - nodeMin) / threads;
         const bitCapInt rMin = nodeMin + threadRange * cpu;
         const bitCapInt rMax = ((cpu + 1U) == threads) ? nodeMax : (nodeMin + threadRange * (cpu + 1U) - 1U);
-#if IS_RSA_SEMIPRIME
-        std::vector<rand_dist> rDist(rangeRange((rMax - rMin) >> 1U));
-#else
         std::vector<rand_dist> rDist(rangeRange(rMax - rMin));
-#endif
 
         for (;;) {
             for (size_t batchItem = 0U; batchItem < BASE_TRIALS; ++batchItem) {
@@ -271,11 +266,7 @@ int main()
                     base <<= WORD_SIZE;
                     base |= rDist[i](rand_gen);
                 }
-#if IS_RSA_SEMIPRIME
-                base = (base << 1U) + rMin;
-#else
                 base += rMin;
-#endif
 
 #define PRINT_SUCCESS(f1, f2, toFactor, message)                                                                       \
     std::cout << message << (f1) << " * " << (f2) << " = " << (toFactor) << std::endl;                                 \

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -222,8 +222,8 @@ int main()
     const bitLenInt primeBits = (qubitCount + 1U) >> 1U;
     const bitCapInt minPrime = primeDict[primeBits].size() ? primeDict[primeBits][0] : ((ONE_BCI << (primeBits - 1U)) + 1U);
     const bitCapInt maxPrime = primeDict[primeBits].size() ? primeDict[primeBits][1] : ((ONE_BCI << primeBits) - 1U);
-    const bitCapInt fullMinBase = ((toFactor / maxPrime) < minPrime) ? minPrime : ((toFactor / maxPrime) | 1U);
-    const bitCapInt fullMaxBase = toFactor / fullMinBase;
+    const bitCapInt fullMinBase = (((toFactor / maxPrime) < minPrime) ? minPrime : ((toFactor / maxPrime) | 1U)) >> 1U;
+    const bitCapInt fullMaxBase = (toFactor / ((fullMinBase << 1U) | 1U)) >> 1U;
 #else
     const bitCapInt fullMinBase = 2U;
     const bitCapInt fullMaxBase = toFactor / 2U;
@@ -266,7 +266,11 @@ int main()
                     base <<= WORD_SIZE;
                     base |= rDist[i](rand_gen);
                 }
+#if IS_RSA_SEMIPRIME
+                base = ((base << 1U) + rMin) | 1U;
+#else
                 base += rMin;
+#endif
 
 #define PRINT_SUCCESS(f1, f2, toFactor, message)                                                                       \
     std::cout << message << (f1) << " * " << (f2) << " = " << (toFactor) << std::endl;                                 \

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -229,7 +229,7 @@ int main()
         { 64U, { 9223372036854775837U, 1844674407370955143U } } };
 
     const bitLenInt primeBits = (qubitCount + 1U) >> 1U;
-    const bitCapInt minPrime = primeDict[primeBits].size() ? primeDict[primeBits][0] : ((ONE_BCI << (primeBits - 1U)) + 1);
+    const bitCapInt minPrime = primeDict[primeBits].size() ? primeDict[primeBits][0] : ((ONE_BCI << (primeBits - 1U)) + 1U);
     const bitCapInt maxPrime = primeDict[primeBits].size() ? primeDict[primeBits][1] : ((ONE_BCI << primeBits) - 1U);
     const bitCapInt fullMinBase = ((toFactor / maxPrime) < minPrime) ? minPrime : ((toFactor / maxPrime) | 1U);
     const bitCapInt fullMaxBase = ((toFactor / minPrime) > maxPrime) ? maxPrime : ((toFactor / minPrime) | 1U);
@@ -257,7 +257,11 @@ int main()
         const bitCapInt threadRange = (nodeMax + 1U - nodeMin) / threads;
         const bitCapInt rMin = nodeMin + threadRange * cpu;
         const bitCapInt rMax = ((cpu + 1U) == threads) ? nodeMax : (nodeMin + threadRange * (cpu + 1U) - 1U);
+#if IS_RSA_SEMIPRIME
+        std::vector<rand_dist> rDist(rangeRange((rMax - rMin) >> 1U));
+#else
         std::vector<rand_dist> rDist(rangeRange(rMax - rMin));
+#endif
 
         for (;;) {
             for (size_t batchItem = 0U; batchItem < BASE_TRIALS; ++batchItem) {
@@ -267,7 +271,11 @@ int main()
                     base <<= WORD_SIZE;
                     base |= rDist[i](rand_gen);
                 }
+#if IS_RSA_SEMIPRIME
+                base = (base << 1U) + rMin;
+#else
                 base += rMin;
+#endif
 
 #define PRINT_SUCCESS(f1, f2, toFactor, message)                                                                       \
     std::cout << message << (f1) << " * " << (f2) << " = " << (toFactor) << std::endl;                                 \

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -293,9 +293,9 @@ int main()
                 // Then, by Euler's theorem, uintpow(base, \phi(toFactor)) % toFactor == 1.
                 // Remember that uintpow(base, 0) == 1.
                 // Euler's totient, \phi(toFactor), is therefore a harmonic of the modular period.
-                // \phi(toFactor) is a multiple of the Carmichael function, \lambda(toFactor)
+                // \phi(toFactor) is a multiple of the Carmichael function, \lambda(toFactor),
                 // defined as as the lowest number for which uintpow(base, \lambda(toFactor)) % toFactor == 1.
-                // Then, \lambda(toFactor) + 1 is the period.
+                // Then, \lambda(toFactor) is the period.
 
 #if IS_RSA_SEMIPRIME
                 // For semiprime numbers, \phi(toFactor) = (p - 1) * (q - 1) for primes "p" and "q".

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -320,7 +320,11 @@ int main()
                 // At this point, p is not a factor, and p is probably not prime.
                 // However, p is "relatively close" to one of our two factors.
 
-                const bitCapInt q = toFactor / p;
+                bitCapInt q = toFactor / p;
+                if ((q & 1U) == 0) {
+                    q |= 1U;
+                    TEST_DIVIDE(q, toFactor, "Guessed q: Found");
+                }
 
                 // At this point, similarly, q is not a factor, and q is probably not prime.
                 // However, q is "relatively close" to one of our two factors.

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -223,10 +223,11 @@ int main()
     const bitCapInt minPrime = primeDict[primeBits].size() ? primeDict[primeBits][0] : ((ONE_BCI << (primeBits - 1U)) + 1U);
     const bitCapInt maxPrime = primeDict[primeBits].size() ? primeDict[primeBits][1] : ((ONE_BCI << primeBits) - 1U);
     const bitCapInt fullMinBase = ((toFactor / maxPrime) < minPrime) ? minPrime : ((toFactor / maxPrime) | 1U);
+    const bitCapInt fullMaxBase = toFactor / fullMinBase;
 #else
     const bitCapInt fullMinBase = 2U;
-#endif
     const bitCapInt fullMaxBase = toFactor / 2U;
+#endif
     const bitCapInt nodeRange = (fullMaxBase + 1U - fullMinBase) / nodeCount;
     const bitCapInt nodeMin = fullMinBase + nodeRange * nodeId;
     const bitCapInt nodeMax = ((nodeId + 1U) == nodeCount) ? fullMaxBase : (fullMinBase + nodeRange * (nodeId + 1U) - 1U);

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -224,18 +224,15 @@ int main()
     isFinished = false;
 
 #if IS_RSA_SEMIPRIME
-    // Minimum prime number in bit width catalog
-    std::map<bitLenInt, bitCapInt> primeDict = {
-        { 16U, 32771U },
-        { 28U, 134217757U },
-        { 32U, 2147483659U },
-        { 64U, 9223372036854775837U }
-    };
+    std::map<bitLenInt, const std::vector<bitCapInt>> primeDict = { { 16U, { 32771U, 65521U } },
+        { 28U, { 134217757U, 268435399U } }, { 32U, { 2147483659U, 4294967291U } },
+        { 64U, { 9223372036854775837U, 1844674407370955143U } } };
 
     const bitLenInt primeBits = (qubitCount + 1U) >> 1U;
-    const bitCapInt minPrime = primeDict[primeBits] ? primeDict[primeBits] : ((ONE_BCI << (primeBits - 1U)) + 1);
-    const bitCapInt fullMinBase = minPrime;
-    const bitCapInt fullMaxBase = toFactor / minPrime;
+    const bitCapInt minPrime = primeDict[primeBits].size() ? primeDict[primeBits][0] : ((ONE_BCI << (primeBits - 1U)) + 1);
+    const bitCapInt maxPrime = primeDict[primeBits].size() ? primeDict[primeBits][1] : ((ONE_BCI << primeBits) - 1U);
+    const bitCapInt fullMinBase = ((toFactor / maxPrime) < minPrime) ? minPrime : ((toFactor / maxPrime) | 1U);
+    const bitCapInt fullMaxBase = ((toFactor / minPrime) > maxPrime) ? maxPrime : ((toFactor / minPrime) | 1U);
 #else
     const bitCapInt fullMinBase = 2U;
     const bitCapInt fullMaxBase = toFactor / 2;

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -307,9 +307,8 @@ int main()
                     phi |= phiDist[i](rand_gen);
                 }
                 phi = ((phi + minPhi) << 2U);
-                // TODO: We have guessed for \phi(toFactor). How do reduce this to \lambda(toFactor)?
 
-                const bitCapInt apowrhalf = uipow(base, phi) % toFactor;
+                const bitCapInt apowrhalf = uipow(base, phi >> 1U) % toFactor;
                 const bitCapInt f1 = gcd(apowrhalf + 1U, toFactor);
                 const bitCapInt f2 = gcd(apowrhalf - 1U, toFactor);
                 if (((f1 * f2) == toFactor) && (f1 > 1U) && (f2 > 1U)) {

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -308,7 +308,15 @@ int main()
                 }
                 phi = ((phi + minPhi) << 2U);
 
-                const bitCapInt apowrhalf = uipow(base, phi >> 1U) % toFactor;
+                bitCapInt apowrhalf;
+                do {
+                    phi >>= 1U;
+                    apowrhalf = uipow(base, phi) % toFactor;
+                } while ((apowrhalf == 1) && (phi > 2U));
+                if (phi < 2U) {
+                    continue;
+                }
+
                 const bitCapInt f1 = gcd(apowrhalf + 1U, toFactor);
                 const bitCapInt f2 = gcd(apowrhalf - 1U, toFactor);
                 if (((f1 * f2) == toFactor) && (f1 > 1U) && (f2 > 1U)) {

--- a/src/qimcifa.cpp
+++ b/src/qimcifa.cpp
@@ -314,23 +314,14 @@ int main()
                     p <<= WORD_SIZE;
                     p |= pDist[i](rand_gen);
                 }
-                p = (p << 1U) + minP;
-                TEST_DIVIDE(p, toFactor, "Guessed p: Found");
-
-                // At this point, p is not a factor, and p is probably not prime.
-                // However, p is "relatively close" to one of our two factors.
-
+                p = ((p << 1U) + minP);
                 bitCapInt q = toFactor / p;
-                if ((q & 1U) == 0) {
-                    q |= 1U;
-                    TEST_DIVIDE(q, toFactor, "Guessed q: Found");
-                }
 
-                // At this point, similarly, q is not a factor, and q is probably not prime.
-                // However, q is "relatively close" to one of our two factors.
-
+                // (p - 1) and (q - 1) are both even.
+                p = p >> 1U;
+                q = q >> 1U;
                 // This guess for lambda might be chaotic.
-                const bitCapInt lambda = (p - 1) * (q - 1) / gcd(p - 1, q - 1);
+                const bitCapInt lambda = p * q / gcd(p, q);
 
                 const bitCapInt apowrhalf = uipow(base, lambda) % toFactor;
                 if ((apowrhalf == 1) || (apowrhalf == (toFactor - 1))) {


### PR DESCRIPTION
We've moving further from the premise of guessing for the outcome of Shor's period finding algorithm, for integer factoring, but this is a practical improvement in speed for `IS_RSA_SEMIPRIME`, nonetheless.

The new premise seems to be: "Guessing among 2^(n/2) options is half the _exponent_ of factoring 2^n options by sieve," (though, even trial division should be asymptotically logarithmic, with a perfect, zero-cost primes table). 