### PR TITLE
Reduce heap usage

### DIFF
--- a/include/prime_generator.hpp
+++ b/include/prime_generator.hpp
@@ -197,6 +197,21 @@ inline size_t GetWheelIncrement(std::vector<boost::dynamic_bitset<size_t>>& inc_
     return wheelIncrement;
 }
 
+inline size_t GetWheel5Increment(uint32_t& wheel5) {
+    size_t wheelIncrement = 0U;
+    bool is_wheel_multiple = false;
+    do {
+        is_wheel_multiple = (bool)(wheel5 & 1U);
+        wheel5 >>= 1U;
+        if (is_wheel_multiple) {
+            wheel5 |= 1U << 9U;
+        }
+        wheelIncrement++;
+    } while (is_wheel_multiple);
+
+    return wheelIncrement;
+}
+
 std::vector<BigInteger> TrialDivision(const BigInteger& n);
 std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n);
 } // namespace qimcifa

--- a/src/prime_gen.cpp
+++ b/src/prime_gen.cpp
@@ -90,16 +90,14 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
     // reverse the true/false meaning, so we can use
     // default initialization. A value in notPrime[i]
     // will finally be false only if i is a prime.
-    const size_t bitsPerWord = 64U;
-    uint64_t notPrime[(cardinality + bitsPerWord) / bitsPerWord];
-    memset(notPrime, 0U, sizeof(notPrime));
+    boost::dynamic_bitset<size_t> notPrime(cardinality + 1U);
 
     // Get the remaining prime numbers.
     dispatch.resetResult();
-    std::vector<boost::dynamic_bitset<size_t>> inc_seqs = wheel_gen(knownPrimes, n);
+    uint32_t wheel5 = (1U << 7U) | 1U;
     size_t o = 1U;
     for (;;) {
-        o += GetWheelIncrement(inc_seqs);
+        o += GetWheel5Increment(wheel5);
 
         const BigInteger p = forward(o);
         if ((p * p) > n) {
@@ -111,9 +109,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             threadLimit *= threadLimit;
         }
 
-
-        const size_t q = (size_t)backward5(p);
-        if ((notPrime[q / bitsPerWord] >> (q % bitsPerWord)) & 1U) {
+        if (notPrime[(size_t)backward5(p)]) {
             continue;
         }
 
@@ -134,8 +130,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             // we can proceed with the 1 remainder loop.
             // This saves 2/3 of updates (or modulo).
             if ((p % 3U) == 2U) {
-                const size_t q = (size_t)backward5(i);
-                notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
+                notPrime[(size_t)backward5(i)] = true;
                 i += p2;
                 if (i > n) {
                     return false;
@@ -147,8 +142,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             for (int j = 0; j < 15; ++j) {
                 wheel30.push_back(i % 5);
                 if (wheel30[wheel30.size() - 1U]) {
-                    const size_t q = (size_t)backward5(i);
-                    notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
+                    notPrime[(size_t)backward5(i)] = true;
                 }
                 i += p4;
                 if (i > n) {
@@ -157,8 +151,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
 
                 wheel30.push_back(i % 5);
                 if (wheel30[wheel30.size() - 1U]) {
-                    const size_t q = (size_t)backward5(i);
-                    notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
+                    notPrime[(size_t)backward5(i)] = true;
                 }
                 i += p2;
                 if (i > n) {
@@ -169,8 +162,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             for (;;) {
                 for (int j = 0; j < 30; j+=2) {
                     if (wheel30[j]) {
-                        const size_t q = (size_t)backward5(i);
-                        notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
+                        notPrime[(size_t)backward5(i)] = true;
                     }
                     i += p4;
                     if (i > n) {
@@ -178,8 +170,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
                     }
 
                     if (wheel30[j + 1]) {
-                        const size_t q = (size_t)backward5(i);
-                        notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
+                        notPrime[(size_t)backward5(i)] = true;
                     }
                     i += p2;
                     if (i > n) {
@@ -194,15 +185,14 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
     dispatch.finish();
 
     for (;;) {
-        o += GetWheelIncrement(inc_seqs);
+        o += GetWheel5Increment(wheel5);
 
         const BigInteger p = forward(o);
         if (p > n) {
             break;
         }
 
-        const size_t q = (size_t)backward5(p);
-        if ((notPrime[q / bitsPerWord] >> (q % bitsPerWord)) & 1U) {
+        if (notPrime[(size_t)backward5(p)]) {
             continue;
         }
 

--- a/src/prime_gen.cpp
+++ b/src/prime_gen.cpp
@@ -76,6 +76,8 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
         return std::vector<BigInteger>(knownPrimes.begin(), highestPrimeIt);
     }
 
+    knownPrimes.reserve(log(n));
+
     BigInteger threadLimit = 26U;
 
     // We are excluding multiples of the first few
@@ -233,6 +235,7 @@ std::vector<BigInteger> SegmentedSieveOfEratosthenes(const BigInteger& n)
 
     // Compute all primes smaller than or equal to limit using simple sieve
     std::vector<BigInteger> knownPrimes = SieveOfEratosthenes(limit);
+    knownPrimes.reserve(log(n));
     dispatch.resetResult();
 
     const size_t bitsPerWord = 64U;

--- a/src/prime_generator.cpp
+++ b/src/prime_generator.cpp
@@ -92,10 +92,10 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
 
     // Get the remaining prime numbers.
     dispatch.resetResult();
-    std::vector<boost::dynamic_bitset<size_t>> inc_seqs = wheel_gen(knownPrimes, n);
+    uint32_t wheel5 = (1U << 7U) | 1U;
     size_t o = 1U;
     for (;;) {
-        o += GetWheelIncrement(inc_seqs);
+        o += GetWheel5Increment(wheel5);
 
         const BigInteger p = forward(o);
         if ((p * p) > n) {
@@ -190,7 +190,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
     dispatch.finish();
 
     for (;;) {
-        o += GetWheelIncrement(inc_seqs);
+        o += GetWheel5Increment(wheel5);
 
         const BigInteger p = forward(o);
         if (p > n) {

--- a/src/prime_generator.cpp
+++ b/src/prime_generator.cpp
@@ -74,6 +74,8 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
         return std::vector<BigInteger>(knownPrimes.begin(), highestPrimeIt);
     }
 
+    knownPrimes.reserve(log(n));
+
     BigInteger threadLimit = 26U;
 
     // We are excluding multiples of the first few
@@ -231,6 +233,7 @@ std::vector<BigInteger> SegmentedSieveOfEratosthenes(const BigInteger& n)
 
     // Compute all primes smaller than or equal to limit using simple sieve
     std::vector<BigInteger> knownPrimes = SieveOfEratosthenes(limit);
+    knownPrimes.reserve(log(n));
     dispatch.resetResult();
 
     const size_t bitsPerWord = 64U;

--- a/src/prime_generator.cpp
+++ b/src/prime_generator.cpp
@@ -88,9 +88,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
     // reverse the true/false meaning, so we can use
     // default initialization. A value in notPrime[i]
     // will finally be false only if i is a prime.
-    const size_t bitsPerWord = 64U;
-    uint64_t notPrime[(cardinality + bitsPerWord) / bitsPerWord];
-    memset(notPrime, 0U, sizeof(notPrime));
+    boost::dynamic_bitset<size_t> notPrime(cardinality + 1U);
 
     // Get the remaining prime numbers.
     dispatch.resetResult();
@@ -109,9 +107,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             threadLimit *= threadLimit;
         }
 
-
-        const size_t q = (size_t)backward5(p);
-        if ((notPrime[q / bitsPerWord] >> (q % bitsPerWord)) & 1U) {
+        if (notPrime[(size_t)backward5(p)]) {
             continue;
         }
 
@@ -132,8 +128,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             // we can proceed with the 1 remainder loop.
             // This saves 2/3 of updates (or modulo).
             if ((p % 3U) == 2U) {
-                const size_t q = (size_t)backward5(i);
-                notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
+                notPrime[(size_t)backward5(i)] = true;
                 i += p2;
                 if (i > n) {
                     return false;
@@ -145,8 +140,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             for (int j = 0; j < 15; ++j) {
                 wheel30.push_back(i % 5);
                 if (wheel30[wheel30.size() - 1U]) {
-                    const size_t q = (size_t)backward5(i);
-                    notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
+                    notPrime[(size_t)backward5(i)] = true;
                 }
                 i += p4;
                 if (i > n) {
@@ -155,8 +149,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
 
                 wheel30.push_back(i % 5);
                 if (wheel30[wheel30.size() - 1U]) {
-                    const size_t q = (size_t)backward5(i);
-                    notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
+                    notPrime[(size_t)backward5(i)] = true;
                 }
                 i += p2;
                 if (i > n) {
@@ -167,8 +160,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             for (;;) {
                 for (int j = 0; j < 30; j+=2) {
                     if (wheel30[j]) {
-                        const size_t q = (size_t)backward5(i);
-                        notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
+                        notPrime[(size_t)backward5(i)] = true;
                     }
                     i += p4;
                     if (i > n) {
@@ -176,8 +168,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
                     }
 
                     if (wheel30[j + 1]) {
-                        const size_t q = (size_t)backward5(i);
-                        notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
+                        notPrime[(size_t)backward5(i)] = true;
                     }
                     i += p2;
                     if (i > n) {
@@ -199,8 +190,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             break;
         }
 
-        const size_t q = (size_t)backward5(p);
-        if ((notPrime[q / bitsPerWord] >> (q % bitsPerWord)) & 1U) {
+        if (notPrime[(size_t)backward5(p)]) {
             continue;
         }
 
@@ -339,7 +329,7 @@ using namespace qimcifa;
 // Driver Code
 int main()
 {
-    BigInteger n = 100000000U; // 1e8
+    BigInteger n = 1000000000U; // 1e9
 
     std::cout << "Primes up to number: ";
     std::cin >> n;
@@ -347,7 +337,7 @@ int main()
     std::cout << "Following are the prime numbers smaller than or equal to " << n << ":" << std::endl;
 
     // const std::vector<BigInteger> primes = TrialDivision(n);
-    const std::vector<BigInteger> primes = SegmentedSieveOfEratosthenes(n);
+    const std::vector<BigInteger> primes = SieveOfEratosthenes(n);
 
     for (BigInteger p : primes) {
         std::cout << p << " ";

--- a/src/prime_generator.cpp
+++ b/src/prime_generator.cpp
@@ -86,7 +86,9 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
     // reverse the true/false meaning, so we can use
     // default initialization. A value in notPrime[i]
     // will finally be false only if i is a prime.
-    boost::dynamic_bitset<size_t> notPrime(cardinality + 1);
+    const size_t bitsPerWord = 64U;
+    uint64_t notPrime[(cardinality + bitsPerWord) / bitsPerWord];
+    memset(notPrime, 0U, sizeof(notPrime));
 
     // Get the remaining prime numbers.
     dispatch.resetResult();
@@ -107,7 +109,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
 
 
         const size_t q = (size_t)backward5(p);
-        if (notPrime[q] == true) {
+        if ((notPrime[q / bitsPerWord] >> (q % bitsPerWord)) & 1U) {
             continue;
         }
 
@@ -128,7 +130,8 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             // we can proceed with the 1 remainder loop.
             // This saves 2/3 of updates (or modulo).
             if ((p % 3U) == 2U) {
-                notPrime[(size_t)backward5(i)] = true;
+                const size_t q = (size_t)backward5(i);
+                notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
                 i += p2;
                 if (i > n) {
                     return false;
@@ -140,7 +143,8 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             for (int j = 0; j < 15; ++j) {
                 wheel30.push_back(i % 5);
                 if (wheel30[wheel30.size() - 1U]) {
-                    notPrime[(size_t)backward5(i)] = true;
+                    const size_t q = (size_t)backward5(i);
+                    notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
                 }
                 i += p4;
                 if (i > n) {
@@ -149,7 +153,8 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
 
                 wheel30.push_back(i % 5);
                 if (wheel30[wheel30.size() - 1U]) {
-                    notPrime[(size_t)backward5(i)] = true;
+                    const size_t q = (size_t)backward5(i);
+                    notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
                 }
                 i += p2;
                 if (i > n) {
@@ -160,7 +165,8 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             for (;;) {
                 for (int j = 0; j < 30; j+=2) {
                     if (wheel30[j]) {
-                        notPrime[(size_t)backward5(i)] = true;
+                        const size_t q = (size_t)backward5(i);
+                        notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
                     }
                     i += p4;
                     if (i > n) {
@@ -168,7 +174,8 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
                     }
 
                     if (wheel30[j + 1]) {
-                        notPrime[(size_t)backward5(i)] = true;
+                        const size_t q = (size_t)backward5(i);
+                        notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
                     }
                     i += p2;
                     if (i > n) {
@@ -190,7 +197,8 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
             break;
         }
 
-        if (notPrime[(size_t)backward5(p)] == true) {
+        const size_t q = (size_t)backward5(p);
+        if ((notPrime[q / bitsPerWord] >> (q % bitsPerWord)) & 1U) {
             continue;
         }
 
@@ -203,8 +211,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
 std::vector<BigInteger> SegmentedSieveOfEratosthenes(const BigInteger& n)
 {
     // TODO: This should scale to the system.
-    // It's 16 GB in bytes.
-    const BigInteger limit = BigInteger(1U) << 37U;
+    const size_t limit = (1ULL << 27U);
 
     // `backward(n)` counts assuming that multiples
     // of 2 and 3 have been removed.
@@ -226,6 +233,8 @@ std::vector<BigInteger> SegmentedSieveOfEratosthenes(const BigInteger& n)
     std::vector<BigInteger> knownPrimes = SieveOfEratosthenes(limit);
     dispatch.resetResult();
 
+    const size_t bitsPerWord = 64U;
+
     // Process one segment at a time until we pass n
     while (low < n) {
         if (high >= n) {
@@ -237,7 +246,9 @@ std::vector<BigInteger> SegmentedSieveOfEratosthenes(const BigInteger& n)
 
         // Cardinality with multiples of 2 and 3 removed is 1/3 of total.
         const BigInteger bLow = backward(low);
-        boost::dynamic_bitset<size_t> notPrime((size_t)(backward(high) - bLow) + 1U);
+        const size_t cardinality = (size_t)(backward(high) - bLow);
+        uint64_t notPrime[(cardinality + bitsPerWord) / bitsPerWord];
+        memset(notPrime, 0U, sizeof(notPrime));
 
         // Use the found primes by simpleSieve() to find
         // primes in current range
@@ -248,7 +259,7 @@ std::vector<BigInteger> SegmentedSieveOfEratosthenes(const BigInteger& n)
             // we start with 33.
             const BigInteger& p = knownPrimes[k];
 
-            dispatch.dispatch([&bLow, &high, &low, p, &notPrime]() {
+            dispatch.dispatch([&bLow, &high, &low, &cardinality, p, &notPrime]() {
                 // We are skipping multiples of 2, 3, and 5
                 // for space complexity, for 4/15 the bits.
                 // More are skipped by the wheel for time.
@@ -270,26 +281,26 @@ std::vector<BigInteger> SegmentedSieveOfEratosthenes(const BigInteger& n)
                 // This saves 2/3 of updates (or modulo).
                 if ((i % 3U) == 2U) {
                     const size_t q = (size_t)(backward(i) - bLow);
-                    if (q >= notPrime.size()) {
+                    if (q > cardinality) {
                         return false;
                     }
-                    notPrime[q] = true;
+                    notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
                     i += p2;
                 }
 
                 for (;;) {
                     size_t q = (size_t)(backward(i) - bLow);
-                    if (q >= notPrime.size()) {
+                    if (q > cardinality) {
                         return false;
                     }
-                    notPrime[q] = true;
+                    notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
                     i += p4;
 
                     q = (size_t)(backward(i) - bLow);
-                    if (q >= notPrime.size()) {
+                    if (q > cardinality) {
                         return false;
                     }
-                    notPrime[q] = true;
+                    notPrime[q / bitsPerWord] |= (1ULL << (q % bitsPerWord));
                     i += p2;
                 }
 
@@ -299,9 +310,9 @@ std::vector<BigInteger> SegmentedSieveOfEratosthenes(const BigInteger& n)
         dispatch.finish();
 
         // Numbers which are not marked as false are prime
-        for (size_t i = 0; i < notPrime.size(); ++i) {
-            if (notPrime[i] == false) {
-                knownPrimes.push_back(forward(i + bLow));
+        for (size_t q = 0; q <= cardinality; ++q) {
+            if ((notPrime[q / bitsPerWord] >> (q % bitsPerWord)) & 1U) {
+                knownPrimes.push_back(forward(q + bLow));
             }
         }
 
@@ -325,7 +336,7 @@ using namespace qimcifa;
 // Driver Code
 int main()
 {
-    BigInteger n = 1000000000U; // 1e9
+    BigInteger n = 100000000U; // 1e8
 
     std::cout << "Primes up to number: ";
     std::cin >> n;

--- a/src/prime_generator.cpp
+++ b/src/prime_generator.cpp
@@ -135,11 +135,10 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
                 }
             }
 
-            boost::dynamic_bitset<size_t> wheel30;
-            wheel30.reserve(30);
-            for (int j = 0; j < 15; ++j) {
-                wheel30.push_back(i % 5);
-                if (wheel30[wheel30.size() - 1U]) {
+            uint32_t wheel30 = 0U;
+            for (int j = 0; j < 30; j += 2) {
+                if (i % 5) {
+                    wheel30 |= (1ULL << j);
                     notPrime[(size_t)backward5(i)] = true;
                 }
                 i += p4;
@@ -147,8 +146,8 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
                     return false;
                 }
 
-                wheel30.push_back(i % 5);
-                if (wheel30[wheel30.size() - 1U]) {
+                if (i % 5) {
+                    wheel30 |= (1ULL << (j + 1U));
                     notPrime[(size_t)backward5(i)] = true;
                 }
                 i += p2;
@@ -159,7 +158,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
 
             for (;;) {
                 for (int j = 0; j < 30; j+=2) {
-                    if (wheel30[j]) {
+                    if ((wheel30 >> j) & 1U) {
                         notPrime[(size_t)backward5(i)] = true;
                     }
                     i += p4;
@@ -167,7 +166,7 @@ std::vector<BigInteger> SieveOfEratosthenes(const BigInteger& n)
                         return false;
                     }
 
-                    if (wheel30[j + 1]) {
+                    if ((wheel30 >> (j + 1)) & 1U) {
                         notPrime[(size_t)backward5(i)] = true;
                     }
                     i += p2;


### PR DESCRIPTION
In the context of Sieve of Eratosthenes, stack allocation should generally be preferred over heap, wherever possible. For now, the bit set for marking primes is still a heap object, as stack is exhausted at a relatively small width, while heap can grow to GBs, and the heap version is currently faster.